### PR TITLE
Added support for MotionChart

### DIFF
--- a/gwt-charts/pom.xml
+++ b/gwt-charts/pom.xml
@@ -108,6 +108,10 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<!-- avoid javdoc error with java 8 -->
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/ChartPackage.java
+++ b/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/ChartPackage.java
@@ -68,7 +68,11 @@ public enum ChartPackage {
 	/**
 	 * Exclusive use for treemap charts.
 	 */
-	TREEMAP("treemap");
+	TREEMAP("treemap"),
+	/**
+	 * Exclusive use for motioncharts charts.
+	 */
+	MOTIONCHART("motionchart");
 
 	/**
 	 * Get a ChartPackage by providing its name.

--- a/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/ChartWidget.java
+++ b/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/ChartWidget.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 public abstract class ChartWidget<T extends Options> extends Widget implements RequiresResize {
 	protected ChartObject chartObject;
 	private DataSource data;
-	private Options options;
+	protected T options;
 	private HashMap<HandlerRef, EventHandler> eventMap;
 	private boolean unloaded;
 	private boolean pending;

--- a/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/motionchart/MotionChart.java
+++ b/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/motionchart/MotionChart.java
@@ -1,0 +1,96 @@
+package com.googlecode.gwt.charts.client.motionchart;
+
+import com.google.gwt.dom.client.Element;
+import com.googlecode.gwt.charts.client.ChartObject;
+import com.googlecode.gwt.charts.client.ChartWidget;
+import com.googlecode.gwt.charts.client.DataSource;
+import com.googlecode.gwt.charts.client.event.ErrorHandler;
+import com.googlecode.gwt.charts.client.event.HandlerRef;
+import com.googlecode.gwt.charts.client.event.ReadyHandler;
+import com.googlecode.gwt.charts.client.event.StateChangeHandler;
+
+
+/**
+ * A dynamic chart to explore several indicators over time. The chart is rendered within the browser using Flash
+ */
+public class MotionChart  extends ChartWidget<MotionChartOptions> {
+
+    private boolean isResponsive = true;
+
+    /**
+     * Creates a new chart widget.
+     */
+    public MotionChart() {
+        super();
+    }
+
+    /**
+     * Adds an handler that listens for error events.
+     *
+     * @param handler the class to call when the event is fired
+     * @return the handler reference
+     */
+    public HandlerRef addErrorHandler(ErrorHandler handler) {
+        return addHandler(handler);
+    }
+
+    /**
+     * Adds an handler that listens for ready events.
+     *
+     * @param handler the class to call when the event is fired
+     * @return the handler reference
+     */
+    public HandlerRef addReadyHandler(ReadyHandler handler) {
+        return addHandler(handler);
+    }
+
+    /**
+     * Adds an handler that listens when user has interacted with the chart in some way.
+     * Call getState() to learn the current state of the chart.
+
+     *
+     * @param handler the class to call when the event is fired
+     * @return the handler reference
+     */
+    public HandlerRef addStateChangeHandler(StateChangeHandler handler) {
+        return addHandler(handler);
+    }
+
+
+    @Override
+    protected void redrawNow() {
+        if (isResponsive) {
+            int height = getParent().getOffsetHeight();
+            if (height > 0) {
+                options.setHeight(height);
+            }
+            int width = getParent().getOffsetWidth();
+            if (width > 0) {
+                options.setWidth(width);
+            }
+        }
+        super.redrawNow();
+    }
+
+    @Override
+    public void draw(DataSource data, MotionChartOptions options) {
+        this.isResponsive = options.getHeight() == null && options.getWidth() == null;
+        super.draw(data, options);
+    }
+
+    /**
+     * Returns the current state of the motionchart, serialized to a JSON string.
+     * To assign this state to the chart, assign this string to the state option in the draw() method.
+     * This is often used to specify a custom chart state on startup, instead of using the default state.
+     *
+     * @return the state of the charts
+     */
+    public native final String getState() /*-{
+         return this.getState();
+    }-*/;
+
+    @Override
+    protected native ChartObject createChartObject(Element container) /*-{
+        return new $wnd.google.visualization.MotionChart(container);
+    }-*/;
+}

--- a/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/motionchart/MotionChartOptions.java
+++ b/gwt-charts/src/main/java/com/googlecode/gwt/charts/client/motionchart/MotionChartOptions.java
@@ -1,0 +1,127 @@
+package com.googlecode.gwt.charts.client.motionchart;
+
+import com.googlecode.gwt.charts.client.options.Options;
+
+/**
+ * Configuration options for {@link MotionChart}.
+ *
+ * @see <a href="https://developers.google.com/chart/interactive/docs/gallery/motionchart#Configuration_Options">Motion Chart
+ *      Configuration Options</a>
+ */
+public class MotionChartOptions extends Options {
+
+    /**
+     * Default constructor.
+     *
+     * @return a new object instance
+     */
+    public static MotionChartOptions create() {
+        return createObject().cast();
+    }
+
+    protected MotionChartOptions() {
+    }
+
+    /**
+     * An initial display state for the chart.
+     * This is a serialized JSON object that describes zoom level, selected dimensions, selected bubbles/entities, and other state descriptions.
+     * See Setting Initial State to learn how to set this.
+     *
+     * @param state (Default: null)
+     */
+    public final native void setState(String state) /*-{
+        this.state = state;
+    }-*/;
+
+    /**
+     * false hides the buttons that control the chart type (bubbles / lines / columns) at top right corner.
+     *
+     * @param showChartButtons (Default: true)
+     */
+    public final native void setShowChartButtons(boolean showChartButtons) /*-{
+        this.showChartButtons = showChartButtons;
+    }-*/;
+
+    /**
+     * false hides the title label of the entities (derived from the label of the first column in the data table).
+     *
+     * @param showHeader (Default: true)
+     */
+    public final native void setShowHeader(boolean showHeader) /*-{
+        this.showHeader = showHeader;
+    }-*/;
+
+    /**
+     * false hides the list of visible entities.
+     *
+     * @param showSelectListComponent (Default: true)
+     */
+    public final native void setShowSelectListComponent(boolean showSelectListComponent) /*-{
+        this.showSelectListComponent = showSelectListComponent;
+    }-*/;
+
+    /**
+     * false hides the right hand panel.
+
+     * @param showSidePanel (Default: true)
+     */
+    public final native void setShowSidePanel(boolean showSidePanel) /*-{
+        this.showSidePanel = showSidePanel;
+    }-*/;
+
+    /**
+     * false hides the metric picker for x.
+     *
+     * @param showXMetricPicker (Default: true)
+     */
+    public final native void setShowXMetricPicker(boolean showXMetricPicker) /*-{
+        this.showXMetricPicker = showXMetricPicker;
+    }-*/;
+
+    /**
+     * false hides the metric picker for y.
+     *
+     * @param showYMetricPicker (Default: true)
+     */
+    public final native void setShowYMetricPicker(boolean showYMetricPicker) /*-{
+        this.showYMetricPicker = showYMetricPicker;
+    }-*/;
+
+    /**
+     * false hides the scale picker for x.
+     *
+     * @param showXScalePicker (Default: true)
+     */
+    public final native void setShowXScalePicker(boolean showXScalePicker) /*-{
+        this.showXScalePicker = showXScalePicker;
+    }-*/;
+
+    /**
+     * false hides the scale picker for y.
+     *
+     * @param showYScalePicker (Default: true)
+     */
+    public final native void setShowYScalePicker(boolean showYScalePicker) /*-{
+        this.showYScalePicker = showYScalePicker;
+    }-*/;
+
+    /**
+     * false disables the options compartment in the settings panel.
+     *
+     * @param showAdvancedPanel (Default: true)
+     */
+    public final native void setShowAdvancedPanel(boolean showAdvancedPanel) /*-{
+        this.showAdvancedPanel = showAdvancedPanel;
+    }-*/;
+
+
+    public final native Integer getWidth() /*-{
+        return this.width;
+    }-*/;
+
+    public final native Integer getHeight() /*-{
+        return this.height;
+    }-*/;
+
+
+}


### PR DESCRIPTION
Add MotionChart and a corresponding MotionChartOptions class and
"motionchart" enum to the ChartPackage class.
Unlike the other charts MotionChart is not responsive. In order to keep the
same behavior as the other  chart types, the MotionChart will determine if
width or height are specified. If not it will assume to resize if the available
space. For this to work, the access level of the  Options variable inside of
the ChartWidget had to be changed from private to protected.

This fixes #53
